### PR TITLE
Add -u parameter to use NONSTANDARD UDP port DNS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 1. Support both UDP and TCP
 2. Detect if a domain is polluted
-3. Query polluted domains over TCP or SOCKS5
+3. Query polluted domains over TCP or SOCKS5 or NONSTANDARD UDP port DNS server 
 
 
 ## Build ##
@@ -76,7 +76,7 @@ cn_server   | DNS server for unpolluted domains, default: 114.114.114.114:53
 server      | DNS server for polluted domains, default: 8.8.8.8:53
 
 **sample config file:**
-
+1. use SOCKS5 proxy
 ```ini
 user=nobody
 group=nobody
@@ -86,10 +86,28 @@ test_server=8.8.8.8:53
 cn_server=114.114.114.114:53
 server=8.8.8.8:53
 ```
+2. use TCP
+```ini
+user=nobody
+group=nobody
+listen=127.0.0.1:5300
+test_server=8.8.8.8:53
+cn_server=114.114.114.114:53
+server=8.8.8.8:53
+```
+3. use UDP and a NONSTANDARD port DNS server
+```ini
+user=nobody
+group=nobody
+listen=127.0.0.1:5300
+test_server=8.8.8.8:53
+cn_server=114.114.114.114:53
+server=208.67.222.222:5353
+```
 
 ## Note ##
 
-1. If SOCKS5 server is not given, polluted domains will be queried over TCP. It's faster than querying over SOCKS5, but may not work in some networks.
+1. If SOCKS5 server is not given, polluted domains will be queried over TCP. It's faster than querying over SOCKS5, but may not work in some networks. if run sans with -u parameter, polluted domains will be queried over UDP. It's faster than TCP but your must make sure you set a NONSTANDARD port DNS server, like 5353, 1053 etc, must not be 53.
 
 2. Since there is no cache in sans, you may need to set it as an upstream DNS server for Dnsmasq instead of using it directly.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ server      | DNS server for polluted domains, default: 8.8.8.8:53
 
 **sample config file:**
 
-1. use SOCKS5 proxy
+use SOCKS5 proxy
 ```ini
 user=nobody
 group=nobody
@@ -87,7 +87,8 @@ test_server=8.8.8.8:53
 cn_server=114.114.114.114:53
 server=8.8.8.8:53
 ```
-2. use TCP
+
+use TCP
 ```ini
 user=nobody
 group=nobody
@@ -96,7 +97,8 @@ test_server=8.8.8.8:53
 cn_server=114.114.114.114:53
 server=8.8.8.8:53
 ```
-3. use UDP and a NONSTANDARD port DNS server
+
+use UDP and a NONSTANDARD port DNS server
 ```ini
 user=nobody
 group=nobody

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ cn_server   | DNS server for unpolluted domains, default: 114.114.114.114:53
 server      | DNS server for polluted domains, default: 8.8.8.8:53
 
 **sample config file:**
+
 1. use SOCKS5 proxy
 ```ini
 user=nobody

--- a/src/conf.c
+++ b/src/conf.c
@@ -52,6 +52,7 @@ static void help(void)
            "  --pidfile <file>     PID file, default: /run/sans.pid\n"
            "  --logfile <file>     log file, default: /var/log/sans.log\n"
            "  -v, --verbose        verbose logging\n"
+           "  -u, --nspresolver    use NoStandardPort UDP Resolver\n"
            "  -V, --version        print version and exit\n\n"
            "Bug report: <%s>.\n", PACKAGE, PACKAGE_BUGREPORT);
 }
@@ -256,6 +257,10 @@ int parse_args(int argc, char **argv, conf_t *conf)
         else if ((strcmp(argv[i], "-v") == 0) || (strcmp(argv[i], "--verbose") == 0))
         {
             conf->verbose = 1;
+        }
+        else if ((strcmp(argv[i], "-u") == 0) || (strcmp(argv[i], "--nspresolver") == 0))
+        {
+            conf->nspresolver = 1;
         }
         else if ((strcmp(argv[i], "-V") == 0) || (strcmp(argv[i], "--version") == 0))
         {

--- a/src/conf.h
+++ b/src/conf.h
@@ -28,6 +28,7 @@
 typedef struct
 {
     int verbose;
+    int nspresolver;
     int daemon;
     char user[16];
     char pidfile[64];


### PR DESCRIPTION
Can run sans with -u parameter, polluted domains will be queried over
UDP. It's faster than TCP.
